### PR TITLE
[APP-5045] [主播風格濾鏡] 當一開始沒有開啟17美肌時, 切換"紋理"跟"風貌剪影"沒有效果

### DIFF
--- a/LFLiveKit/Vendor/QBGLKit/filter/base/QBGLFilter.h
+++ b/LFLiveKit/Vendor/QBGLKit/filter/base/QBGLFilter.h
@@ -56,6 +56,8 @@ typedef NS_ENUM(NSUInteger, QBGLImageRotation) {
 
 - (NSArray<QBGLDrawable*> *)renderTextures;
 
+- (void)setAdditionalUniformVarsForRender;
+
 /**
  * Prepare for drawing and return the next available active texture index.
  */

--- a/LFLiveKit/Vendor/QBGLKit/filter/base/QBGLFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/base/QBGLFilter.m
@@ -136,6 +136,10 @@ char * const kQBNoFilterFragment;
     return nil;
 }
 
+- (void)setAdditionalUniformVarsForRender {
+    // do nothing
+}
+
 - (GLuint)render {
     [_program use];
     [_program enableAttributeWithId:_attrPosition];
@@ -143,6 +147,8 @@ char * const kQBNoFilterFragment;
     
     glVertexAttribPointer(_attrPosition, 2, GL_FLOAT, 0, 0, squareVertices);
     glVertexAttribPointer(_attrInputTextureCoordinate, 2, GL_FLOAT, 0, 0, [self.class textureCoordinatesForRotation:_inputRotation]);
+    
+    [self setAdditionalUniformVarsForRender];
     
     GLuint index = 0;
     if (_inputImageDrawable) {

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLCrayonFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLCrayonFilter.m
@@ -33,10 +33,11 @@ char * const kQBCrayonFilterFragment;
     [self.program setParameter:"strength" floatValue:1.0];
 }
 
-- (GLuint)render {
+- (void)setAdditionalUniformVarsForRender {
+    [super setAdditionalUniformVarsForRender];
+    
     const GLfloat offset[] = {1 / self.inputSize.width, 1 / self.inputSize.height};
     glUniform2fv([self.program uniformWithName:"singleStepOffset"], 1, offset);
-    return [super render];
 }
 
 @end

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLFreudFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLFreudFilter.m
@@ -40,10 +40,11 @@ char * const kQBFreudFilterFragment;
     return @[_randDrawable];
 }
 
-- (GLuint)render {
+- (void)setAdditionalUniformVarsForRender {
+    [super setAdditionalUniformVarsForRender];
+    
     [self.program setParameter:"inputImageTextureWidth" floatValue:self.inputSize.width];
     [self.program setParameter:"inputImageTextureHeight" floatValue:self.inputSize.height];
-    return [super render];
 }
 
 @end

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLHealthyFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLHealthyFilter.m
@@ -54,10 +54,11 @@ char * const kQBHealthyFilterFragment;
     return @[_curveDrawable, _maskDrawable];
 }
 
-- (GLuint)render {
+- (void)setAdditionalUniformVarsForRender {
+    [super setAdditionalUniformVarsForRender];
+    
     [self.program setParameter:"texelWidthOffset" floatValue:1 / self.inputSize.width];
     [self.program setParameter:"texelHeightOffset" floatValue:1 / self.inputSize.height];
-    return [super render];
 }
 
 @end

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLNostalgiaFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLNostalgiaFilter.m
@@ -77,10 +77,11 @@ char * const kQBNostalgiaFilterFragment;
     return @[_curveDrawable, _curve2Drawable];
 }
 
-- (GLuint)render {
+- (void)setAdditionalUniformVarsForRender {
+    [super setAdditionalUniformVarsForRender];
+    
     [self.program setParameter:"texelWidthOffset" floatValue:1 / self.inputSize.width];
     [self.program setParameter:"texelHeightOffset" floatValue:1 / self.inputSize.height];
-    return [super render];
 }
 
 @end

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLSakuraFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLSakuraFilter.m
@@ -50,10 +50,11 @@ char * const kQBSakuraFilterFragment;
     return @[_curveDrawable];
 }
 
-- (GLuint)render {
+- (void)setAdditionalUniformVarsForRender {
+    [super setAdditionalUniformVarsForRender];
+    
     [self.program setParameter:"texelWidthOffset" floatValue:1 / self.inputSize.width];
     [self.program setParameter:"texelHeightOffset" floatValue:1 / self.inputSize.height];
-    return [super render];
 }
 
 @end

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLSketchFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLSketchFilter.m
@@ -34,10 +34,11 @@ char * const kQBSketchFilterFragment;
     [self.program setParameter:"strength" floatValue:1.0];
 }
 
-- (GLuint)render {
+- (void)setAdditionalUniformVarsForRender {
+    [super setAdditionalUniformVarsForRender];
+    
     const GLfloat offset[] = {1 / self.inputSize.width, 1 / self.inputSize.height};
     glUniform2fv([self.program uniformWithName:"singleStepOffset"], 1, offset);
-    return [super render];
 }
 
 @end

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLSkinWhiteFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLSkinWhiteFilter.m
@@ -50,10 +50,11 @@ char * const kQBSkinWhiteFilterFragment;
     return @[_curveDrawable];
 }
 
-- (GLuint)render {
+- (void)setAdditionalUniformVarsForRender {
+    [super setAdditionalUniformVarsForRender];
+    
     [self.program setParameter:"texelWidthOffset" floatValue:1 / self.inputSize.width];
     [self.program setParameter:"texelHeightOffset" floatValue:1 / self.inputSize.height];
-    return [super render];
 }
 
 @end

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLSweetsFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLSweetsFilter.m
@@ -52,10 +52,11 @@ char * const kQBSweetsFilterFragment;
     return @[_curveDrawable, _image1Drawable];
 }
 
-- (GLuint)render {
+- (void)setAdditionalUniformVarsForRender {
+    [super setAdditionalUniformVarsForRender];
+    
     [self.program setParameter:"texelWidthOffset" floatValue:1 / self.inputSize.width];
     [self.program setParameter:"texelHeightOffset" floatValue:1 / self.inputSize.height];
-    return [super render];
 }
 
 @end


### PR DESCRIPTION
#### Why

Root cause: 當設定shader內要用到的變數時, 沒有設定到正確的program.

#### How

Solution: 先設定到正確的program之後再設定變數

#### Risk

Low

[[APP-5045] [主播風格濾鏡] 當一開始沒有開啟17美肌時, 切換"紋理"跟"風貌剪影"沒有效果](https://17media.atlassian.net/browse/APP-5045)
