### PR TITLE
[APP-6532] [主播直播間] 開播期間當弱網或是斷網時, 記憶體使用量會不斷上升, 一直到恢復網路

### DIFF
--- a/LFLiveKit/publish/LFStreamRtmpSocket.m
+++ b/LFLiveKit/publish/LFStreamRtmpSocket.m
@@ -167,7 +167,10 @@ SAVC(mp4a);
             _self.isSending = YES;
 
             if (!_self.isConnected || _self.isReconnecting || _self.isConnecting || !_rtmp){
-                _self.isSending = NO;
+                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                    //< 这里只为了不循环调用sendFrame方法 调用栈是保证先出栈再进栈
+                    _self.isSending = NO;
+                });
                 return;
             }
 


### PR DESCRIPTION
#### Why

記憶體使用量不斷上升, 因為不斷的產生auto release pool記憶體給block區間使用.

#### How

Solution: 先切換到不同的dispatch queue, 導致記憶體釋放, 再切回rtmpSendQueue.

#### Risk

Low

[[APP-6532] [主播直播間] 開播期間當弱網或是斷網時, 記憶體使用量會不斷上升, 一直到恢復網路](https://17media.atlassian.net/browse/APP-6532)