### PR TITLE
修正錯誤

### DIFF
--- a/LFLiveKit/publish/LFStreamRtmpSocket.m
+++ b/LFLiveKit/publish/LFStreamRtmpSocket.m
@@ -168,6 +168,12 @@ SAVC(mp4a);
 
 - (void)streamURLChanged:(NSString *)url {
     dispatch_async(self.rtmpSendQueue, ^{
+        if (_rtmp != NULL) {
+            PILI_RTMP_Close(_rtmp, &_error);
+            PILI_RTMP_Free(_rtmp);
+            _rtmp = NULL;
+        }
+
         self.stream.url = url;
         [self clean];
         [self start];


### PR DESCRIPTION
#### What

1. 在重啟RTMP socket之前必須得先關閉.
2. Crash發生在CFRelease(compressionSession).

#### Why

2. reset與encodeVideoData:timeStamp:, 此兩function有機會同時要做CFRelease(compressionSession), 但caller就是在不同的thread, 導致race condition發生在compressionSession.

#### How

Solution
2. 加入flag "isResetting".當在reset時, 不執行encodeVideoData:timeStamp:.

#### Risk

Low
