### PR TITLE
恢復推流時支援傳入新的push URL & RTMP socket連結成功後, 要清掉retry connect的次數

### DIFF
--- a/LFLiveKit/LFLiveSession.h
+++ b/LFLiveKit/LFLiveSession.h
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSUInteger, RKReplayKitSampleType) {
 - (void)liveSession:(nullable LFLiveSession *)session audioDataBeforeMixing:(nullable NSData *)audioData;
 
 - (nullable CVPixelBufferRef)liveSession:(nullable LFLiveSession *)session willOutputVideoFrame:(nonnull CVPixelBufferRef)pixelBuffer atTime:(CMTime)time customTime:(uint64_t)customTime;
-- (void)liveSession:(nullable LFLiveSession *)session willOutputAudioFrame:(unsigned char *)data samples:(NSUInteger)samples customTime:(uint64_t)customTime;
+- (void)liveSession:(nullable LFLiveSession *)session willOutputAudioFrame:(unsigned char * _Nullable)data samples:(NSUInteger)samples customTime:(uint64_t)customTime;
 
 @end
 
@@ -174,7 +174,7 @@ typedef NS_ENUM(NSUInteger, RKReplayKitSampleType) {
 @property (strong, nonatomic, readonly) EAGLContext * _Nullable glContext;
 
 // 是否要停止將採集到的video/audio data做encode, 沒有encoded的data就不會推送到rtmp
-@property (assign, nonatomic) BOOL stopEncodingVideoAudioData;
+@property (assign, nonatomic, readonly) BOOL stopEncodingVideoAudioData;
 
 #pragma mark - Initializer
 ///=============================================================================
@@ -210,7 +210,13 @@ typedef NS_ENUM(NSUInteger, RKReplayKitSampleType) {
 - (void)startLive:(nonnull LFLiveStreamInfo *)streamInfo;
 
 /** Update stream url */
-- (void)updateStreamURL:(NSString *)url;
+- (void)updateStreamURL:(nonnull NSString *)url;
+
+/** 停止將採集到的video/audio data做encode, 沒有encoded的data就不會推送到rtmp */
+- (void)pauseLive;
+
+/** 恢復將採集到的video/audio data做encode, 並且使用新的push URL來推流 */
+- (void)resumeLive:(nonnull NSString *)pushURL;
 
 /** The stop stream .*/
 - (void)stopLive;

--- a/LFLiveKit/publish/LFStreamRtmpSocket.m
+++ b/LFLiveKit/publish/LFStreamRtmpSocket.m
@@ -337,6 +337,7 @@ SAVC(mp4a);
     _isConnecting = NO;
     _isReconnecting = NO;
     _isSending = NO;
+    _retryTimes4netWorkBreaken = 0;
     return 0;
     
 Failed:


### PR DESCRIPTION
#### What

1. 恢復推流時支援傳入新的push URL
2. RTMP socket連結成功後, 要清掉retry connect的次數

#### Why

1. 因為push URL可能因為鑑權的關係已經過期
2. 不然事後再發生reconnect時, 有可能會直接達到retry上限而關播

#### How

Solution
1. 使用新的functions "pauseLive" & "resumeLive"來控制stopEncodingVideoAudioData
2. RTMP connect成功後, 清除retry connect次數

#### Risk

Low
