### PR TITLE
修復重連rtmp時有機率Crash

### DIFF
--- a/LFLiveKit/publish/LFStreamRtmpSocket.m
+++ b/LFLiveKit/publish/LFStreamRtmpSocket.m
@@ -168,6 +168,7 @@ SAVC(mp4a);
 
 - (void)streamURLChanged:(NSString *)url {
     dispatch_async(self.rtmpSendQueue, ^{
+        [NSObject cancelPreviousPerformRequestsWithTarget:self];
         if (_rtmp != NULL) {
             PILI_RTMP_Close(_rtmp, &_error);
             PILI_RTMP_Free(_rtmp);
@@ -684,9 +685,6 @@ print_bytes(void   *start,
 
 - (void)_reconnect{
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
-    
-    _isReconnecting = NO;
-    if(_isConnected) return;
     
     _isReconnecting = NO;
     if (_isConnected) return;


### PR DESCRIPTION
#### Why

```
 _rtmp 已經被release, 但在另一個queue被存取導致crash
```

#### How

```
stramURLChanged時先將之前perform在main queue的_reconnect function cancel
```

#### Risk

```
Low
```