### PR TITLE
修復支援使用QBGLKit但不使用Camera 360

### DIFF
--- a/LFLiveKit/Vendor/QBGLKit/core/QBGLContext.h
+++ b/LFLiveKit/Vendor/QBGLKit/core/QBGLContext.h
@@ -20,11 +20,15 @@
 @property (nonatomic, readonly) CVPixelBufferRef outputPixelBuffer;
 
 @property (nonatomic) CGSize outputSize;
+@property (nonatomic) CGSize viewPortSize;
 
 @property (nonatomic) QBGLFilterType colorFilterType;
 @property (nonatomic) BOOL beautyEnabled;
 
 @property (strong, nonatomic) UIView *animationView;
+
+@property (assign, nonatomic, readonly) BOOL hasMagicFilter;
+@property (assign, nonatomic, readonly) BOOL hasMultiFilters;
 
 - (instancetype)initWithContext:(EAGLContext *)context animationView:(UIView *)animationView;
 
@@ -36,6 +40,18 @@
 
 - (void)renderToOutput;
 
-- (void)setDisplayOrientation:(UIInterfaceOrientation)orientation cameraPosition:(AVCaptureDevicePosition)position;
+- (void)setDisplayOrientation:(UIInterfaceOrientation)orientation cameraPosition:(AVCaptureDevicePosition)position mirror:(BOOL)mirror;
+
+#pragma mark - Animation
+
+- (void)setPreviewAnimationOrientationWithCameraPosition:(AVCaptureDevicePosition)position mirror:(BOOL)mirror;
+
+#pragma mark - Preview
+
+- (void)setPreviewDisplayOrientation:(UIInterfaceOrientation)orientation cameraPosition:(AVCaptureDevicePosition)position;
+- (void)configInputFilterToPreview;
+- (void)renderInputFilterToPreview;
+- (void)renderInputFilterToOutputFilter;
+- (void)renderOutputFilterToPreview;
 
 @end

--- a/LFLiveKit/Vendor/QBGLKit/filter/base/QBGLFilter.h
+++ b/LFLiveKit/Vendor/QBGLKit/filter/base/QBGLFilter.h
@@ -19,7 +19,11 @@ typedef NS_ENUM(NSUInteger, QBGLImageRotation) {
     QBGLImageRotationFlipHorizonal,
     QBGLImageRotationRightFlipVertical,
     QBGLImageRotationRightFlipHorizontal,
-    QBGLImageRotation180
+    QBGLImageRotation180,
+    QBGLImageRotationLeftFlipVertical,
+    QBGLImageRotationLeftFlipHorizontal,
+    QBGLImageRotation180FlipVertical,
+    QBGLImageRotation180FlipHorizontal
 };
 
 @class QBGLProgram;
@@ -29,8 +33,10 @@ typedef NS_ENUM(NSUInteger, QBGLImageRotation) {
 @property (strong, nonatomic, readonly) QBGLProgram *program;
 
 @property (nonatomic) QBGLImageRotation inputRotation;
+@property (nonatomic) QBGLImageRotation animationRotation;
 @property (nonatomic) CGSize inputSize;
 @property (nonatomic) CGSize outputSize;
+@property (nonatomic) CGSize viewPortSize;
 
 @property (nonatomic) CVOpenGLESTextureCacheRef textureCacheRef;
 @property (nonatomic) GLuint outputTextureId;

--- a/LFLiveKit/Vendor/QBGLKit/filter/base/QBGLFilter.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/base/QBGLFilter.m
@@ -69,18 +69,20 @@ char * const kQBNoFilterFragment;
         0.0f, 1.0f,
     };
     
+    // vertical flip first and then rotate right
     static const GLfloat rotateRightVerticalFlipTextureCoordinates[] = {
-        0.0f, 0.0f,
-        0.0f, 1.0f,
-        1.0f, 0.0f,
         1.0f, 1.0f,
+        1.0f, 0.0f,
+        0.0f, 1.0f,
+        0.0f, 0.0f,
     };
     
+    // horizontal flip first and then rotate right
     static const GLfloat rotateRightHorizontalFlipTextureCoordinates[] = {
-        1.0f, 1.0f,
-        1.0f, 0.0f,
-        0.0f, 1.0f,
         0.0f, 0.0f,
+        0.0f, 1.0f,
+        1.0f, 0.0f,
+        1.0f, 1.0f,
     };
     
     static const GLfloat rotate180TextureCoordinates[] = {
@@ -88,6 +90,38 @@ char * const kQBNoFilterFragment;
         0.0f, 1.0f,
         1.0f, 0.0f,
         0.0f, 0.0f,
+    };
+    
+    // vertical flip first and then rotate left
+    static const GLfloat rotateLeftVerticalFlipTextureCoordinates[] = {
+        0.0f, 0.0f,
+        0.0f, 1.0f,
+        1.0f, 0.0f,
+        1.0f, 1.0f,
+    };
+    
+    // horizontal flip first and then rotate left
+    static const GLfloat rotateLeftHorizontalFlipTextureCoordinates[] = {
+        1.0f, 1.0f,
+        1.0f, 0.0f,
+        0.0f, 1.0f,
+        0.0f, 0.0f,
+    };
+    
+    // vertical flip first and then rotate 180
+    static const GLfloat rotate180VerticalFlipTextureCoordinates[] = {
+        1.0f, 0.0f,
+        0.0f, 0.0f,
+        1.0f, 1.0f,
+        0.0f, 1.0f,
+    };
+    
+    // horizontal flip first and then rotate 180
+    static const GLfloat rotate180HorizontalFlipTextureCoordinates[] = {
+        0.0f, 1.0f,
+        1.0f, 1.0f,
+        0.0f, 0.0f,
+        1.0f, 0.0f,
     };
     
     switch(rotation) {
@@ -107,6 +141,14 @@ char * const kQBNoFilterFragment;
             return rotateRightHorizontalFlipTextureCoordinates;
         case QBGLImageRotation180:
             return rotate180TextureCoordinates;
+        case QBGLImageRotationLeftFlipVertical:
+            return rotateLeftVerticalFlipTextureCoordinates;
+        case QBGLImageRotationLeftFlipHorizontal:
+            return rotateLeftHorizontalFlipTextureCoordinates;
+        case QBGLImageRotation180FlipVertical:
+            return rotate180VerticalFlipTextureCoordinates;
+        case QBGLImageRotation180FlipHorizontal:
+            return rotate180HorizontalFlipTextureCoordinates;
     }
 }
 
@@ -204,7 +246,7 @@ char * const kQBNoFilterFragment;
     [self.program setParameter:"enableAnimationView" intValue:(self.enableAnimationView ? 1 : 0)];
     if (self.animationView) {
         [self.program enableAttributeWithId:self.attrInputAnimationCoordinate];
-        glVertexAttribPointer(self.attrInputAnimationCoordinate, 2, GL_FLOAT, 0, 0, [QBGLFilter textureCoordinatesForRotation:QBGLImageRotationNone]);
+        glVertexAttribPointer(self.attrInputAnimationCoordinate, 2, GL_FLOAT, 0, 0, [self.class textureCoordinatesForRotation:_animationRotation]);
     }
 }
 
@@ -240,7 +282,7 @@ char * const kQBNoFilterFragment;
 }
 
 - (void)draw {
-    glViewport(0, 0, _outputSize.width, _outputSize.height);
+    glViewport(0, 0, _viewPortSize.width, _viewPortSize.height);
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
     glClear(GL_COLOR_BUFFER_BIT);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLMagicFilterFactory.h
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLMagicFilterFactory.h
@@ -25,5 +25,6 @@
 - (void)clearCache;
 - (void)preloadFiltersWithTextureCacheRef:(CVOpenGLESTextureCacheRef)textureCacheRef animationView:(UIView *)animationView;
 - (void)updateInputOutputSizeForFilters:(CGSize)outputSize;
+- (void)updateViewPortSizeForFilters:(CGSize)viewPortSize;
 
 @end

--- a/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLMagicFilterFactory.m
+++ b/LFLiveKit/Vendor/QBGLKit/filter/magic/QBGLMagicFilterFactory.m
@@ -57,6 +57,13 @@
     }];
 }
 
+- (void)updateViewPortSizeForFilters:(CGSize)viewPortSize {
+    [_filterCache enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+        QBGLMagicFilterBase *filter = obj;
+        filter.viewPortSize = viewPortSize;
+    }];
+}
+
 + (QBGLMagicFilterBase *)createFilterWithType:(QBGLFilterType)type animationView:(UIView *)animationView {
     switch (type) {
 //        case QBGLFilterTypeAmaro:


### PR DESCRIPTION
1. 將viewPortSize與outputSize拆開, 因為streamer preview與推流output的viewPortSize不同
2. 設置transform matrix給GLKView, 因為GLKView顯示的影像會有奇怪的方向
3. 新增render function for GLKView
4. 不使用camera360時, 鏡像功能交由原本的inputRotation, 新增previewInputRotation給preview使用, 餵入的影像不做鏡像
5. 修正手勢禮動畫的鏡像顯示問題