### PR TITLE
修正切換濾鏡時可能Crash的潛在Issue

### DIFF
--- a/LFLiveKit/Vendor/QBGLKit/core/QBGLContext.h
+++ b/LFLiveKit/Vendor/QBGLKit/core/QBGLContext.h
@@ -23,6 +23,8 @@
 @property (nonatomic) CGSize viewPortSize;
 
 @property (nonatomic) QBGLFilterType colorFilterType;
+@property (nonatomic) QBGLFilterType colorFilterTypeForRender;
+
 @property (nonatomic) BOOL beautyEnabled;
 
 @property (strong, nonatomic) UIView *animationView;

--- a/LFLiveKit/Vendor/QBGLKit/core/QBGLContext.m
+++ b/LFLiveKit/Vendor/QBGLKit/core/QBGLContext.m
@@ -99,9 +99,9 @@
         _colorFilter = [[QBGLColorMapFilter alloc] initWithAnimationView:self.animationView];
         _colorFilter.textureCacheRef = _textureCacheRef;
     }
-    if (_colorFilter.type != _colorFilterType) {
-        [QBGLFilterFactory refactorColorFilter:_colorFilter withType:_colorFilterType];
-        _colorFilter.type = _colorFilterType;
+    if (_colorFilter.type != _colorFilterTypeForRender) {
+        [QBGLFilterFactory refactorColorFilter:_colorFilter withType:_colorFilterTypeForRender];
+        _colorFilter.type = _colorFilterTypeForRender;
     }
     return _colorFilter;
 }
@@ -111,27 +111,27 @@
         _beautyColorFilter = [[QBGLBeautyColorMapFilter alloc] initWithAnimationView:self.animationView];
         _beautyColorFilter.textureCacheRef = _textureCacheRef;
     }
-    if (_beautyColorFilter.type != _colorFilterType) {
-        [QBGLFilterFactory refactorColorFilter:_beautyColorFilter withType:_colorFilterType];
-        _beautyColorFilter.type = _colorFilterType;
+    if (_beautyColorFilter.type != _colorFilterTypeForRender) {
+        [QBGLFilterFactory refactorColorFilter:_beautyColorFilter withType:_colorFilterTypeForRender];
+        _beautyColorFilter.type = _colorFilterTypeForRender;
     }
     return _beautyColorFilter;
 }
 
 - (QBGLMagicFilterBase *)magicFilter {
-    if (!_magicFilter || (_colorFilterType != QBGLFilterTypeNone && _magicFilter.type != _colorFilterType)) {
-        _magicFilter = [self.magicFilterFactory filterWithType:_colorFilterType animationView:self.animationView];
+    if (!_magicFilter || (_colorFilterTypeForRender != QBGLFilterTypeNone && _magicFilter.type != _colorFilterTypeForRender)) {
+        _magicFilter = [self.magicFilterFactory filterWithType:_colorFilterTypeForRender animationView:self.animationView];
     }
     return _magicFilter;
 }
 
 - (QBGLYuvFilter *)filter {
-    BOOL colorFilterType17 = (_colorFilterType > QBGLFilterTypeNone && _colorFilterType < QBGLFilterTypeFairytale);
-    if (_beautyEnabled && _colorFilterType != QBGLFilterTypeNone) {
+    BOOL colorFilterType17 = (_colorFilterTypeForRender > QBGLFilterTypeNone && _colorFilterTypeForRender < QBGLFilterTypeFairytale);
+    if (_beautyEnabled && _colorFilterTypeForRender != QBGLFilterTypeNone) {
         return (colorFilterType17 ? self.beautyColorFilter : self.beautyFilter);
-    } else if (_beautyEnabled && _colorFilterType == QBGLFilterTypeNone) {
+    } else if (_beautyEnabled && _colorFilterTypeForRender == QBGLFilterTypeNone) {
         return self.beautyFilter;
-    } else if (!_beautyEnabled && _colorFilterType != QBGLFilterTypeNone) {
+    } else if (!_beautyEnabled && _colorFilterTypeForRender != QBGLFilterTypeNone) {
         return (colorFilterType17 ? self.colorFilter : self.normalFilter);
     } else {
         return self.normalFilter;
@@ -143,7 +143,7 @@
 }
 
 - (QBGLFilter *)outputFilter {
-    BOOL colorFilterTypeMagic = (_colorFilterType >= QBGLFilterTypeFairytale && _colorFilterType <= QBGLFilterTypeWalden);
+    BOOL colorFilterTypeMagic = (_colorFilterTypeForRender >= QBGLFilterTypeFairytale && _colorFilterTypeForRender <= QBGLFilterTypeWalden);
     return (colorFilterTypeMagic ? self.magicFilter : self.filter);
 }
 

--- a/LFLiveKit/capture/RKVideoCapture.m
+++ b/LFLiveKit/capture/RKVideoCapture.m
@@ -294,6 +294,8 @@
         CMTime time = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
         [self.delegate captureRawCamera:self pixelBuffer:pixelBuffer atTime:time];
     }
+    // 每個frame重取colorFilterType
+    self.glContext.colorFilterTypeForRender = self.glContext.colorFilterType;
     
     [self.glContext loadYUVPixelBuffer:pixelBuffer];
     


### PR DESCRIPTION
#### What
```
[What] 新增colorFilterTypeForRender處理colorFilter
```

#### Why

```
[Why] video render pipe內會去挑選filter, 參考的條件有QBGLContext.colorFilterType, 但是修改此變數跟讀取此變數是在不同的thread上, 有race condition的可能性, 進而導致crash

```

#### How

```
[How] 修改以下 :
1. 每次user更新濾鏡時的動作不變, 一樣是改colorFilterType
2. 在每次didCaptureVideoSample拿到新frame時重新將colorFilterType assign 給  colorFilterTypeForRender
3. QBGLContex的filter getter則參照colorFilterTypeForRender

user改了colorFilterType需要等到下一次取frame時才會將新的值給colorFilterTypeForRender
而取frame以及filter getter是處於同一個thread, 所以避免了race condition

```

#### Risk

```
Medium
```
